### PR TITLE
Removed debug messages

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -103,8 +103,8 @@ void Task::processIO()
 
 
     /* DEBUG + TESTING */
-    mp_bd970->printBufferNMEA();
-    mp_bd970->printNMEA();
+    /*mp_bd970->printBufferNMEA();
+    mp_bd970->printNMEA();*/
 }
 
 


### PR DESCRIPTION
The debug messages keep spamming the terminal which has more important messages to convey. It looks like the debug messages are a forgotten temporary measurement. I suggest to commenting them out.